### PR TITLE
storage path taken by laravel helper

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -21,14 +21,14 @@ class Pdf
     {
         $key = time() . '-' . rand(10000, 99999);
 
-        $htmlFile = '../storage/page-' . $key . '.html';
-        $pdfFile = '../storage/page-' . $key . '.pdf';
+        $htmlFile = storage_path() . '/page-' . $key . '.html';
+        $pdfFile = storage_path() . '/page-' . $key . '.pdf';
 
         file_put_contents($htmlFile, $input);
 
         $generatedFile = $this->executeCommand($htmlFile, $pdfFile);
 
-        $file = $generatedFile ?: '';
+        $file = $generatedFile ? : '';
 
         return $this->removeAndReturnFile($htmlFile, $pdfFile, $file);
 
@@ -41,7 +41,7 @@ class Pdf
      * @param $input
      * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    
+
     public function download($input)
     {
         $file = $this->generatePdf($input);


### PR DESCRIPTION
The storage path is ok while running from any web client but it return exception while running from queue worker. The storage path now taken from laravel helper function storage_path()